### PR TITLE
Update envoy-openssl for arm/Z/P platforms

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ load("//bazel:repositories.bzl", "define_envoy_implementation")
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
-# Commit date: 06/18/25
+# Commit date: 06/25/25
 ENVOY_SHA = "e9fb31fa22ac1bce2fe24d55810ab15f0fc4cf65"
 
 ENVOY_SHA256 = "e39d37f5b721024633ce65d2af1528646b1fe44b75f150f84c6210db95a50af3"
@@ -30,8 +30,8 @@ ENVOY_ORG = "envoyproxy"
 
 ENVOY_REPO = "envoy"
 
-OPENSSL_ENVOY_SHA = "08a71207339c1a24f95d27d9f17c5b14ca0dd24e"
-OPENSSL_ENVOY_SHA256 = "6fde31377ee6aeedee20dacb352dd0e0f3382a498caca28b314fbcf7891e4911"
+OPENSSL_ENVOY_SHA = "e0568a983e6236e042d9e887a82d9fb342fb6bda"
+OPENSSL_ENVOY_SHA256 = "6d4ccfe35361e7f04e2e87288ea661004e1c43f8d1004c3d6d0b1279c0049abd"
 OPENSSL_ENVOY_ORG = "envoyproxy"
 OPENSSL_ENVOY_REPO = "envoy-openssl"
 

--- a/ossm/vendor/envoy/bssl-compat/third_party/boringssl/src/include/openssl/target.h
+++ b/ossm/vendor/envoy/bssl-compat/third_party/boringssl/src/include/openssl/target.h
@@ -54,6 +54,10 @@
 #define OPENSSL_32_BIT
 #elif defined(__myriad2__)
 #define OPENSSL_32_BIT
+#elif defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+#define OPENSSL_64_BIT
+#elif defined(__ppc64le__) || defined(__ARCH_PPC64LE__) || defined(_ARCH_PPC64)
+#define OPENSSL_64_BIT
 #else
 // The list above enumerates the platforms that BoringSSL supports. For these
 // platforms we keep a reasonable bar of not breaking them: automated test

--- a/ossm/vendor/pick_envoy/load_envoy.bzl
+++ b/ossm/vendor/pick_envoy/load_envoy.bzl
@@ -12,9 +12,9 @@ OPENSSL_DISABLED_EXTENSIONS = [
 def load_envoy():
     http_archive(
         name = "envoy",
-        sha256 = "6fde31377ee6aeedee20dacb352dd0e0f3382a498caca28b314fbcf7891e4911",
-        strip_prefix = "envoy-openssl-08a71207339c1a24f95d27d9f17c5b14ca0dd24e",
-        url = "https://github.com/envoyproxy/envoy-openssl/archive/08a71207339c1a24f95d27d9f17c5b14ca0dd24e.tar.gz",
+        sha256 = "6d4ccfe35361e7f04e2e87288ea661004e1c43f8d1004c3d6d0b1279c0049abd",
+        strip_prefix = "envoy-openssl-e0568a983e6236e042d9e887a82d9fb342fb6bda",
+        url = "https://github.com/envoyproxy/envoy-openssl/archive/e0568a983e6236e042d9e887a82d9fb342fb6bda.tar.gz",
         patch_args = ["-p1"],
         patches = [
             "@io_istio_proxy//ossm/patches:use-cmake-from-host.patch",


### PR DESCRIPTION
Add necessary flags management to build in arm64, Z/P platforms.