### PR TITLE
Use OpenSSL from the build environment rather than vendoring it

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,13 @@ workspace(name = "io_istio_proxy")
 
 load("//bazel:repositories.bzl", "define_envoy_implementation")
 
+# Use OpenSSL from the system rather than vendoring it
+new_local_repository(
+    name = "openssl",
+    path = "/usr/lib64/",
+    build_file = "//:openssl.BUILD"
+)
+
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #

--- a/openssl.BUILD
+++ b/openssl.BUILD
@@ -1,0 +1,39 @@
+licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "openssl",
+    srcs = [
+        "libssl.so.3",
+        "libcrypto.so.3",
+    ],
+    visibility = ["//visibility:public"],
+    linkstatic=False,
+)
+
+# Take the shared libs from the system location and copy them into the expected
+# structure that will get copied into the runfiles directory when running tests
+# executables, thus enabling the compatibility layer to load them.
+genrule(
+    name = "create_openssl_lib_structure",
+    srcs = [
+        "libssl.so.3",
+        "libcrypto.so.3",
+    ],
+    outs = [
+        "openssl/lib/libssl.so.3",
+        "openssl/lib/libcrypto.so.3",
+    ],
+    cmd = "mkdir -p $$(dirname $(location openssl/lib/libssl.so.3)) && " +
+          "cp $(location libssl.so.3) $(location openssl/lib/libssl.so.3) && " +
+          "cp $(location libcrypto.so.3) $(location openssl/lib/libcrypto.so.3)",
+    visibility = ["//visibility:private"],
+)
+
+# This is the target that @envoy//bssl-compat:bssl-compat depends on as a *data*
+# dependency, so that the OpenSSL shared libraries are made available in the
+# runfiles directory when running tests executables.
+filegroup(
+    name = "libs",
+    srcs = [":create_openssl_lib_structure"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Use OpenSSL from the build environment rather than vendoring it.