### PR TITLE
Stop the Update Envoy job failing fast

### DIFF
--- a/.github/workflows/update-envoy.yaml
+++ b/.github/workflows/update-envoy.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         branch: [release-1.24, release-1.26, release-1.27, release-1.28]
 


### PR DESCRIPTION
In the Update Envoy workflow, if one branch fails to update, it should not stop the other branches from successfully updating.