### PR TITLE
[release-1.27] stats: utilize expiration

### DIFF
--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -454,7 +454,7 @@ class RotatingScope : public Logger::Loggable<Logger::Id::filter> {
 public:
   RotatingScope(Server::Configuration::FactoryContext& factory_context, uint64_t rotate_interval_ms,
                 uint64_t delete_interval_ms)
-      : parent_scope_(factory_context.scope()), active_scope_(parent_scope_.createScope("")),
+      : parent_scope_(factory_context.scope()), active_scope_(parent_scope_.createScope("", true)),
         raw_scope_(active_scope_.get()), rotate_interval_ms_(rotate_interval_ms),
         delete_interval_ms_(delete_interval_ms) {
     if (rotate_interval_ms_ > 0) {
@@ -483,7 +483,7 @@ private:
     ENVOY_LOG(info, "Rotating active Istio stats scope after {}ms.", rotate_interval_ms_);
     draining_scope_ = active_scope_;
     delete_timer_->enableTimer(std::chrono::milliseconds(delete_interval_ms_));
-    active_scope_ = parent_scope_.createScope("");
+    active_scope_ = parent_scope_.createScope("", true);
     raw_scope_.store(active_scope_.get());
     rotate_timer_->enableTimer(std::chrono::milliseconds(rotate_interval_ms_));
   }

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -52,6 +52,7 @@ func init() {
 		"TestStatsPayload/UseHostHeader/",
 		"TestStatsParserRegression",
 		"TestStatsExpiry",
+		"TestStatsEviction",
 		"TestTCPMetadataExchange/false",
 		"TestTCPMetadataExchange/true",
 		"TestTCPMetadataExchangeNoAlpn",

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -937,6 +937,48 @@ func TestStatsExpiry(t *testing.T) {
 	}
 }
 
+func TestStatsEviction(t *testing.T) {
+	params := driver.NewTestParams(t, map[string]string{
+		"RequestCount": "1",
+		"StatsConfig": driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl") + "\n" +
+			driver.LoadTestData("testdata/bootstrap/stats_expiry.yaml.tmpl"),
+		"StatsFilterClientConfig": driver.LoadTestJSON("testdata/stats/client_config.yaml"),
+		"StatsFilterServerConfig": driver.LoadTestJSON("testdata/stats/server_config.yaml"),
+	}, envoye2e.ProxyE2ETests)
+	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
+	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
+	enableStats(t, params.Vars)
+	if err := (&driver.Scenario{
+		Steps: []driver.Step{
+			&driver.XDS{},
+			&driver.Update{
+				Node:      "client",
+				Version:   "0",
+				Clusters:  []string{params.LoadTestData("testdata/cluster/server.yaml.tmpl")},
+				Listeners: []string{params.LoadTestData("testdata/listener/client.yaml.tmpl")},
+			},
+			&driver.Update{Node: "server", Version: "0", Listeners: []string{params.LoadTestData("testdata/listener/server.yaml.tmpl")}},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
+			&driver.Sleep{Duration: 1 * time.Second},
+			&driver.Repeat{
+				N: 1,
+				Step: &driver.HTTPCall{
+					Port: params.Ports.ClientPort,
+					Body: "hello, world!",
+				},
+			},
+			&driver.Sleep{Duration: 4 * time.Second},
+			&driver.Stats{AdminPort: params.Ports.ClientAdmin, Matchers: map[string]driver.StatMatcher{
+				"istio_requests_total": &driver.MissingStat{Metric: "istio_requests_total"},
+				"istio_build":          &driver.ExactStat{Metric: "testdata/metric/istio_build.yaml"},
+			}},
+		},
+	}).Run(params); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStatsDestinationServiceNamespacePrecedence(t *testing.T) {
 	clientStats := map[string]driver.StatMatcher{
 		"istio_requests_total": &driver.ExactStat{Metric: "testdata/metric/client_request_total_cluster_metadata_precedence.yaml.tmpl"},

--- a/testdata/bootstrap/stats_expiry.yaml.tmpl
+++ b/testdata/bootstrap/stats_expiry.yaml.tmpl
@@ -1,0 +1,2 @@
+stats_flush_interval: 1s
+stats_eviction_interval: 1s


### PR DESCRIPTION
Back port of:

- istio/proxy#6529

This is part of a coordinated backport to back port stats eviction support from Envoy 1.36 / Istio 1.28 to Envoy 1.35 / Istio 1.27, to address unbounded metric memory growth in waypoint proxies. The full set of changes to be back ported across repositories:

- envoyproxy/envoy#40395
- envoyproxy/envoy#42168
- istio/proxy#6529 (This PR)
- istio/api#3562
- istio/istio#57736
- istio/istio#58570