### PR TITLE
ci: add branch protection with required Testing Farm checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
-      - release-1.28
       - release-1.30
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,47 +3,65 @@ name: Proxy build (Testing Farm)
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number (passed by ok-to-test.yaml)"
+        required: true
+        type: string
+      head_sha:
+        description: "PR head SHA to build"
+        required: true
+        type: string
+      base_ref:
+        description: "PR base branch (e.g. release-1.30)"
+        required: true
+        type: string
+      source_repo:
+        description: "PR head repo clone URL"
+        required: true
+        type: string
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     branches:
       - release-1.28
       - release-1.30
 
 jobs:
-  remove-label:
+  manage-labels:
     runs-on: ubuntu-latest
-    if: github.event.action == 'synchronize'
+    if: github.event_name == 'pull_request_target'
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      - name: Add needs-ok-to-test for external contributors
+        if: |
+          github.event.pull_request.author_association != 'OWNER' &&
+          github.event.pull_request.author_association != 'MEMBER' &&
+          github.event.pull_request.author_association != 'COLLABORATOR'
+        uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.removeLabel({
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['needs-ok-to-test']
+            }).catch(() => {})
+
+      - name: Remove ok-to-test on new commit
+        if: github.event.action == 'synchronize'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               name: 'ok-to-test'
-            }).catch(() => {} )
+            }).catch(() => {})
 
   build:
     runs-on: ubuntu-latest
-    # run either because the author is in the VIP list or
-    # because someone added the ok-to-test label
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.action != 'labeled' &&
-        (
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
-        )
-      ) ||
-      (
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'ok-to-test'
-      )
     permissions:
       statuses: write
       pull-requests: write
@@ -53,11 +71,32 @@ jobs:
         include:
           - arch: x86_64
             suffix: ""
-            status_name: Testing Farm bare metal
+            name_suffix: ""
+            status_name: x86_64 bare metal
           - arch: aarch64
             suffix: "-arm64"
-            status_name: Testing Farm bare metal arm64
+            name_suffix: " arm64"
+            status_name: arm64 bare metal
+    name: "build (${{ matrix.arch }}, Testing Farm bare metal${{ matrix.name_suffix }})"
     steps:
+      - name: Check authorization
+        run: |
+          # workflow_dispatch is always authorized:
+          # only ok-to-test.yaml calls createWorkflowDispatch, and only after
+          # a maintainer adds the ok-to-test label
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Triggered via workflow_dispatch (ok-to-test authorized)"
+            exit 0
+          fi
+          ASSOCIATION="${{ github.event.pull_request.author_association }}"
+          if [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || \
+                "$ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "Trusted author ($ASSOCIATION)"
+            exit 0
+          fi
+          echo "::error::External contributor. A maintainer must add the 'ok-to-test' label to run CI."
+          exit 1
+
       - name: Run build on Testing Farm bare metal
         id: tf
         uses: sclorg/testing-farm-as-github-action@v4
@@ -65,24 +104,24 @@ jobs:
           api_key: ${{ secrets.TESTING_FARM_PUBLIC_API_TOKEN }}
           api_url: https://api.testing-farm.io/v0.1
           git_url: https://github.com/openshift-service-mesh/proxy.git
-          git_ref: ${{ github.base_ref || github.ref_name }}
+          git_ref: ${{ inputs.base_ref || github.base_ref || github.ref_name }}
           tmt_plan_regex: /plans/build
           compose: CentOS-Stream-10
           arch: ${{ matrix.arch }}
           tmt_hardware: '{"virtualization": {"is-virtualized": false}}'
-          variables: "SOURCE_REPO=${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }};SOURCE_REF=${{ github.event.pull_request.head.sha || github.sha }}"
+          variables: "SOURCE_REPO=${{ inputs.source_repo || github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }};SOURCE_REF=${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}"
           timeout: 120
           update_pull_request_status: true
           pull_request_status_name: ${{ matrix.status_name }}
           create_issue_comment: true
-          commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
-          pr_number: ${{ github.event.pull_request.number || '' }}
+          commit_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}
+          pr_number: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
 
       - name: Collect build artifact
         if: success()
         env:
           REQUEST_ID: ${{ steps.tf.outputs.request_id }}
-          SOURCE_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+          SOURCE_REF: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}
           SUFFIX: ${{ matrix.suffix }}
         run: |
           ARTIFACTS_URL="https://artifacts.dev.testing-farm.io/${REQUEST_ID}"
@@ -99,7 +138,6 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: envoy-alpha-${{ github.event.pull_request.head.sha || github.sha }}${{ matrix.suffix }}
-          path: envoy-alpha-${{ github.event.pull_request.head.sha || github.sha }}${{ matrix.suffix }}.tar.gz
+          name: envoy-alpha-${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}${{ matrix.suffix }}
+          path: envoy-alpha-${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}${{ matrix.suffix }}.tar.gz
           retention-days: 7
-

--- a/.github/workflows/ok-to-test.yaml
+++ b/.github/workflows/ok-to-test.yaml
@@ -1,0 +1,49 @@
+---
+name: Handle ok-to-test label
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - release-1.30
+
+jobs:
+  label-management:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'ok-to-test'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove needs-ok-to-test when maintainer authorizes CI
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'needs-ok-to-test'
+            }).catch(() => {})
+
+  trigger-build:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'ok-to-test'
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger build.yaml for this PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yaml',
+              ref: context.payload.pull_request.base.ref,
+              inputs: {
+                pr_number: String(context.payload.pull_request.number),
+                head_sha: context.payload.pull_request.head.sha,
+                base_ref: context.payload.pull_request.base.ref,
+                source_repo: context.payload.pull_request.head.repo.clone_url
+              }
+            })


### PR DESCRIPTION
## TL;DR

The Testing Farm pipeline introduced in PR #222 now enforces branch
protection. No PR can merge on `release-1.30` without a successful
Testing Farm run. This required reworking how the workflows trigger and
report results. The details are in the Background section if you want
to understand why.

## How CI will work after this PR merges

**For org members** (OWNER, MEMBER, COLLABORATOR):

1. Open a PR and `build.yaml` triggers automatically. Testing Farm
   runs the build on x86_64 and arm64 bare metal.
2. Results appear as commit statuses on the PR.
3. Once checks pass and the PR has an approval, it can merge.

**For external contributors:**

1. Open a PR. The `needs-ok-to-test` label is added automatically and
   Testing Farm does not run.
2. A maintainer reviews the code and adds the `ok-to-test` label.
3. `ok-to-test.yaml` removes `needs-ok-to-test` and triggers the build.
4. Testing Farm runs and posts results on the PR.
5. Once checks pass and the PR has an approval, it can merge.
6. If the contributor pushes a new commit, `ok-to-test` is removed and
   the maintainer must authorize again.

## Background

This PR builds on top of [PR #222](https://github.com/openshift-service-mesh/proxy/pull/222), which introduced the GHA + Testing Farm
pipeline as a replacement for the Prow-based CI on `release-1.30`.

Once PR #222 merged, the next step was to enforce the new pipeline via branch
protection so no PR can merge without a successful Testing Farm run. While
setting this up we ran into a problem with how GitHub tracks CI results.

### The problem: GitHub tracks CI results per commit, not per workflow run

When GitHub decides if a PR can merge, it asks a very specific question:
"does the last commit of this PR have the required checks passing?"

It does not care about workflows in general. It looks at that specific commit
SHA and checks whether the results are attached to it.

The flow for external contributors is:
1. External contributor opens a PR (last commit SHA: `PR-abc123`)
2. A maintainer adds the `ok-to-test` label
3. `ok-to-test.yaml` triggers `build.yaml` by telling GitHub: "run this
   workflow pointing at branch `release-1.30`"
4. GitHub runs the build and records the result, but attaches it to the
   current tip of `release-1.30` (`release-xyz999`), not to the PR commit
5. Branch protection asks: "does `PR-abc123` have the required checks?"
   The answer is no, because the result is on the wrong commit.
6. The PR can never merge.

### The fix: use Testing Farm commit statuses instead of GHA check-runs

Testing Farm Action (TFaGA) exposes a `commit_sha` parameter that lets you
specify exactly which commit the result should be posted against,
independently of where GitHub ran the workflow. By setting
`commit_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}`,
we ensure TFaGA always posts the result on the PR head SHA regardless of
how the workflow was triggered.

This is why the required checks for branch protection must be the TFaGA
commit status names (`Testing Farm - x86_64 bare metal`) and not the GHA
job names. Only TFaGA, configured this way, guarantees the result lands
on the right commit.

The branch protection rules themselves are managed by the Prow
branch-protector, which periodically overwrites GitHub's settings based on
`_prowconfig.yaml` in `openshift/release`. This is why the new required
context names need to be declared there (PR [#81076](https://github.com/openshift/release/pull/81076)). Any manual change
to branch protection on GitHub gets overwritten within an hour. That PR
will be updated once this one merges and the commit status names are
confirmed empirically.

## Summary

### `.github/workflows/build.yaml` (modified)

- `workflow_dispatch` now declares 4 explicit inputs (`pr_number`,
  `head_sha`, `base_ref`, `source_repo`). These are passed by
  `ok-to-test.yaml` when dispatching for external contributors.
- Removed `labeled` from `pull_request_target` types. Any label event
  (including bot labels like `size/S`) was triggering spurious workflow
  runs and polluting check-run state.
- Replaced job-level `if:` with a step-level "Check authorization" that
  calls `exit 1` for external contributors. This distinction matters for
  branch protection: when a job is skipped via a job-level `if: false`,
  GitHub creates a check-run with `conclusion: skipped` and GitHub
  treats `skipped` exactly the same as `success` when evaluating required
  checks. This means an external contributor's PR would appear to have
  passed CI even though Testing Farm never ran, and the PR could be
  merged. A step that calls `exit 1` instead produces
  `conclusion: failure`, which actually blocks the merge. Additionally,
  when `exit 1` fires, TFaGA never runs and posts no commit status on the
  PR head SHA. A missing required check also blocks branch protection,
  providing a second layer of enforcement.
- Renamed job `remove-label` to `manage-labels`. Added step to attach
  `needs-ok-to-test` label to PRs from external contributors.
- Changed `status_name` from `Testing Farm bare metal` to
  `x86_64 bare metal` / `arm64 bare metal`. TFaGA prepends
  `Testing Farm - ` to this value, so the old names produced
  `Testing Farm - Testing Farm bare metal` (redundant). New commit
  status contexts: `Testing Farm - x86_64 bare metal` and
  `Testing Farm - arm64 bare metal`.
- Added `name_suffix` matrix key to stabilize the GHA job check-run name.

### `.github/workflows/ok-to-test.yaml` (new)

- Triggered on `pull_request_target: [labeled]` for `release-1.30` only.
- Two jobs, both guarded by `if: github.event.label.name == 'ok-to-test'`:
  - `label-management`: removes `needs-ok-to-test` when a maintainer
    authorizes CI
  - `trigger-build`: dispatches `build.yaml` with the PR's `head_sha`,
    `pr_number`, `base_ref`, and `source_repo` as inputs

### Why two workflows

If `labeled` stayed in `build.yaml`, bot labels arriving seconds after
`opened` would trigger the build job. The job would then either skip
(producing `skipped` check-runs that overwrite real ones) or fail on the
authorization step (marking the PR red for an unrelated label). Separating
into two files ensures `build.yaml` only runs on `opened` / `synchronize`
/ `reopened` and never creates spurious check-runs for label events.