### PR TITLE
ci: add ok-to-test label to merge-upstream bot PRs

### DIFF
--- a/.github/workflows/merge-upstream.yaml
+++ b/.github/workflows/merge-upstream.yaml
@@ -64,3 +64,4 @@ jobs:
         labels: |
           auto-merge
           tide/merge-method-merge
+          ok-to-test


### PR DESCRIPTION
TF has never run for bot-created PRs: the build.yaml job is consistently skipped on the opened event, so the required Testing Farm status checks are never written and Tide cannot merge.

Adding ok-to-test triggers ok-to-test.yaml via the labeled event, which dispatches build.yaml through workflow_dispatch — a path that does not depend on author_association and runs TF unconditionally


