### PR TITLE
ci: authorize builds when ok-to-test label is present

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,13 @@ jobs:
             echo "Trusted author ($ASSOCIATION)"
             exit 0
           fi
+          # ok-to-test label means a maintainer explicitly authorized this PR.
+          # Only people with write access can add labels, so this is safe.
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}" == "true" ]]; then
+            echo "ok-to-test label present - authorized by maintainer"
+            exit 0
+          fi
+
           echo "::error::External contributor. A maintainer must add the 'ok-to-test' label to run CI."
           exit 1
 


### PR DESCRIPTION
## Problem

  The `Check authorization` step in `build.yaml` only passes for:
  - `workflow_dispatch` triggers (ok-to-test path via ok-to-test.yaml)
  - Authors with `author_association` of OWNER, MEMBER, or COLLABORATOR

  GitHub evaluates `author_association` using only *public* org membership.
  Members with private membership get `NONE`, so their PRs fail the auth
  check even though they are trusted authors. This affects the
  `merge-upstream` bot and any team member who hasn't made their
  membership public.

  The result is noisy FAILURE CheckRuns on every bot PR, even when
  Testing Farm is running correctly via the `workflow_dispatch` path.

  ## Fix

  Add a third authorization path: if the `ok-to-test` label is present,
  the build is authorized. Only users with triage access or above to the repo can
  add labels, so this is equivalent in security to the MEMBER check.

<!-- testing-farm = {"lock":"false","comment-id":"4866612012","data":[{"id":"68fe4096-98ee-464f-95dd-336ca95db911","name":"arm64 bare metal","status":"complete","outcome":"passed","runTime":1877.156301,"created":"2026-07-02T13:33:05.443327","updated":"2026-07-02T13:33:05.443332","compose":"CentOS-Stream-10","arch":"aarch64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/68fe4096-98ee-464f-95dd-336ca95db911\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/68fe4096-98ee-464f-95dd-336ca95db911/pipeline.log\">pipeline</a>"]},{"id":"4cf25ba7-09b2-4630-83b1-1804e24d947f","name":"x86_64 bare metal","runTime":3421.952441,"created":"2026-07-02T13:33:04.716067","updated":"2026-07-02T13:33:04.716078","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/4cf25ba7-09b2-4630-83b1-1804e24d947f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4cf25ba7-09b2-4630-83b1-1804e24d947f/pipeline.log\">pipeline</a>"]}]} -->