### PR TITLE
CI redesign

### DIFF
--- a/.github/scripts/upload-to-gcs.sh
+++ b/.github/scripts/upload-to-gcs.sh
@@ -16,6 +16,7 @@ if [[ "${DRY_RUN:-false}" == "true" ]]; then
 fi
 
 echo "${GCS_SERVICE_ACCOUNT_KEY}" > /tmp/gcs-key.json
+trap 'rm -f /tmp/gcs-key.json' EXIT
 pip install --quiet google-cloud-storage
 python3 - <<'EOF'
 import os

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number (passed by ok-to-test.yaml)"
+        description: "PR number"
         required: true
         type: string
       head_sha:
@@ -17,48 +17,15 @@ on:
         required: true
         type: string
       source_repo:
-        description: "PR head repo clone URL"
+        description: "PR head repo clone URL (github.com HTTPS only)"
         required: true
         type: string
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches:
-      - release-1.30
+
+concurrency:
+  group: build-pr-${{ inputs.pr_number }}
+  cancel-in-progress: true
 
 jobs:
-  manage-labels:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add needs-ok-to-test for external contributors
-        if: |
-          github.event.pull_request.author_association != 'OWNER' &&
-          github.event.pull_request.author_association != 'MEMBER' &&
-          github.event.pull_request.author_association != 'COLLABORATOR'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: ['needs-ok-to-test']
-            }).catch(() => {})
-
-      - name: Remove ok-to-test on new commit
-        if: github.event.action == 'synchronize'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              name: 'ok-to-test'
-            }).catch(() => {})
-
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -78,65 +45,98 @@ jobs:
             status_name: arm64 bare metal
     name: "build (${{ matrix.arch }}, Testing Farm bare metal${{ matrix.name_suffix }})"
     steps:
-      - name: Check authorization
-        run: |
-          # workflow_dispatch is always authorized:
-          # only ok-to-test.yaml calls createWorkflowDispatch, and only after
-          # a maintainer adds the ok-to-test label
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Triggered via workflow_dispatch (ok-to-test authorized)"
-            exit 0
-          fi
-          ASSOCIATION="${{ github.event.pull_request.author_association }}"
-          if [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || \
-                "$ASSOCIATION" == "COLLABORATOR" ]]; then
-            echo "Trusted author ($ASSOCIATION)"
-            exit 0
-          fi
-          echo "::error::External contributor. A maintainer must add the 'ok-to-test' label to run CI."
-          exit 1
+      - name: Validate inputs
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
+          INPUT_SOURCE_REPO: ${{ inputs.source_repo }}
+        with:
+          script: |
+            // Read inputs from env vars (never interpolate untrusted values directly in JS)
+            const prNumber = parseInt(process.env.INPUT_PR_NUMBER);
+            const headSha = process.env.INPUT_HEAD_SHA;
+            const sourceRepo = process.env.INPUT_SOURCE_REPO;
+
+            if (isNaN(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid pr_number: ${process.env.INPUT_PR_NUMBER}`);
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/.test(headSha)) {
+              core.setFailed(`Invalid head_sha format: ${headSha}`);
+              return;
+            }
+            if (!/^https:\/\/github\.com\/[a-zA-Z0-9_.\-]+\/[a-zA-Z0-9_.\-]+\.git$/.test(sourceRepo)) {
+              core.setFailed(`Invalid source_repo (must be a github.com HTTPS URL): ${sourceRepo}`);
+              return;
+            }
+
+            // Validate that head_sha belongs to the PR
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            if (pr.head.sha !== headSha) {
+              const compare = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: headSha,
+                head: pr.head.sha
+              });
+              if (!['ahead', 'identical'].includes(compare.data.status)) {
+                core.setFailed(`head_sha ${headSha} does not belong to PR #${prNumber} (compare status: ${compare.data.status})`);
+                return;
+              }
+              core.warning(`Building ancestor commit ${headSha} (PR HEAD is now ${pr.head.sha})`);
+            }
+
+            // Verify source_repo matches PR head repo (defense-in-depth)
+            if (pr.head.repo && sourceRepo !== pr.head.repo.clone_url) {
+              core.warning(`source_repo ${sourceRepo} differs from PR head repo ${pr.head.repo.clone_url}`);
+            }
+
+            core.info(`Inputs validated: PR #${prNumber}, SHA ${headSha}`);
 
       - name: Run build on Testing Farm bare metal
         id: tf
-        uses: sclorg/testing-farm-as-github-action@v4
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1  # v4
         with:
           api_key: ${{ secrets.TESTING_FARM_PUBLIC_API_TOKEN }}
           api_url: https://api.testing-farm.io/v0.1
           git_url: https://github.com/openshift-service-mesh/proxy.git
-          git_ref: ${{ inputs.base_ref || github.base_ref || github.ref_name }}
+          git_ref: ${{ inputs.base_ref }}
           tmt_plan_regex: /plans/build
           compose: CentOS-Stream-10
           arch: ${{ matrix.arch }}
           tmt_hardware: '{"virtualization": {"is-virtualized": false}}'
-          variables: "SOURCE_REPO=${{ inputs.source_repo || github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }};SOURCE_REF=${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}"
+          variables: "SOURCE_REPO=${{ inputs.source_repo }};SOURCE_REF=${{ inputs.head_sha }}"
           timeout: 120
           update_pull_request_status: true
           pull_request_status_name: ${{ matrix.status_name }}
           create_issue_comment: true
-          commit_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}
-          pr_number: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
+          commit_sha: ${{ inputs.head_sha }}
+          pr_number: ${{ inputs.pr_number }}
 
       - name: Collect build artifact
         if: success()
         env:
           REQUEST_ID: ${{ steps.tf.outputs.request_id }}
-          SOURCE_REF: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}
+          SOURCE_REF: ${{ inputs.head_sha }}
           SUFFIX: ${{ matrix.suffix }}
         run: |
           ARTIFACTS_URL="https://artifacts.dev.testing-farm.io/${REQUEST_ID}"
           ARTIFACT="envoy-alpha-${SOURCE_REF}${SUFFIX}.tar.gz"
-          echo "Fetching results.xml to locate artifact URL..."
           curl -fSL -o results.xml "${ARTIFACTS_URL}/results.xml"
           TF_PATH=$(grep -oP 'href="\K[^"]+'"${ARTIFACT}"'[^"]*' results.xml | head -1)
           [[ -z "${TF_PATH}" ]] && { echo "ERROR: ${ARTIFACT} not found in results.xml"; cat results.xml; exit 1; }
-          echo "Downloading: ${TF_PATH}"
           curl -fSL -o "${ARTIFACT}" "${TF_PATH}"
-          echo "Downloaded: ${ARTIFACT} ($(du -sh "${ARTIFACT}" | cut -f1))"
 
       - name: Upload build artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: envoy-alpha-${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}${{ matrix.suffix }}
-          path: envoy-alpha-${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}${{ matrix.suffix }}.tar.gz
+          name: envoy-alpha-${{ inputs.head_sha }}${{ matrix.suffix }}
+          path: envoy-alpha-${{ inputs.head_sha }}${{ matrix.suffix }}.tar.gz
           retention-days: 7

--- a/.github/workflows/ci-auth.yaml
+++ b/.github/workflows/ci-auth.yaml
@@ -1,0 +1,93 @@
+---
+name: CI Authorization
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - release-1.30
+
+concurrency:
+  group: ci-auth-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: write
+    steps:
+      - name: Check authorization and manage CI
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const login = context.payload.pull_request.user.login;
+            const assoc = context.payload.pull_request.author_association;
+            const prNumber = context.payload.pull_request.number;
+            const action = context.payload.action;
+
+            const dispatchBuild = async () => {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'build.yaml',
+                ref: context.payload.pull_request.base.ref,
+                inputs: {
+                  pr_number: String(prNumber),
+                  head_sha: context.payload.pull_request.head.sha,
+                  base_ref: context.payload.pull_request.base.ref,
+                  source_repo: context.payload.pull_request.head.repo?.clone_url ?? ''
+                }
+              });
+            };
+
+            // Trusted: public org membership visible via author_association
+            if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc)) {
+              core.info(`Trusted: ${login} (${assoc})`);
+              await dispatchBuild();
+              return;
+            }
+
+            // Not trusted via author_association (private member or external contributor)
+            core.info(`Not trusted via association: ${login} (${assoc})`);
+
+            // On synchronize/reopened: remove ok-to-test to invalidate previous authorization
+            if (action === 'synchronize' || action === 'reopened') {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: 'ok-to-test'
+              }).catch(() => {});
+            }
+
+            // Add needs-ok-to-test
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['needs-ok-to-test']
+            }).catch(() => {});
+
+            // Live API check: if ok-to-test already on the PR at open time
+            // (e.g. bot PRs created by merge-upstream.yaml with ok-to-test in labels),
+            // dispatch the build and clean up needs-ok-to-test.
+            // This is a fresh API call, NOT the frozen event snapshot.
+            if (action === 'opened') {
+              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+              });
+              if (currentLabels.some(l => l.name === 'ok-to-test')) {
+                core.info(`ok-to-test already present. Dispatching build and removing needs-ok-to-test.`);
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: 'needs-ok-to-test'
+                }).catch(() => {});
+                await dispatchBuild();
+              }
+            }

--- a/.github/workflows/merge-upstream.yaml
+++ b/.github/workflows/merge-upstream.yaml
@@ -5,21 +5,19 @@ on:
     - cron: "10 */12 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   merge-upstream:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
         branch: [release-1.28, release-1.30]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{ matrix.branch }}
         fetch-depth: 0
@@ -51,7 +49,7 @@ jobs:
 
     - name: Create the PR
       if: steps.merge.outputs.already-synced != 'true'
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
       with:
         token: ${{ secrets.GIT_TOKEN }}
         branch: merge-upstream-${{ matrix.branch }}

--- a/.github/workflows/ok-to-test.yaml
+++ b/.github/workflows/ok-to-test.yaml
@@ -8,31 +8,15 @@ on:
       - release-1.30
 
 jobs:
-  label-management:
+  handle-ok-to-test:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'ok-to-test'
     permissions:
       pull-requests: write
-    steps:
-      - name: Remove needs-ok-to-test when maintainer authorizes CI
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              name: 'needs-ok-to-test'
-            }).catch(() => {})
-
-  trigger-build:
-    runs-on: ubuntu-latest
-    if: github.event.label.name == 'ok-to-test'
-    permissions:
       actions: write
     steps:
-      - name: Trigger build.yaml for this PR
-        uses: actions/github-script@v7
+      - name: Dispatch build
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
@@ -44,6 +28,17 @@ jobs:
                 pr_number: String(context.payload.pull_request.number),
                 head_sha: context.payload.pull_request.head.sha,
                 base_ref: context.payload.pull_request.base.ref,
-                source_repo: context.payload.pull_request.head.repo.clone_url
+                source_repo: context.payload.pull_request.head.repo?.clone_url ?? ''
               }
-            })
+            });
+
+      - name: Remove needs-ok-to-test
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'needs-ok-to-test'
+            }).catch(() => {});

--- a/plans/common.sh
+++ b/plans/common.sh
@@ -1,8 +1,19 @@
 sysctl -w user.max_user_namespaces=15000
 
-git clone ${SOURCE_REPO} proxy-src
+# Validate SOURCE_REPO is a github.com HTTPS URL (prevents shell injection and SSRF)
+if [[ ! "${SOURCE_REPO}" =~ ^https://github\.com/[a-zA-Z0-9_.\-]+/[a-zA-Z0-9_.\-]+\.git$ ]]; then
+  echo "ERROR: SOURCE_REPO must be a github.com HTTPS URL, got: ${SOURCE_REPO}" >&2
+  exit 1
+fi
+# Validate SOURCE_REF is a 40-char hex SHA (prevents shell injection)
+if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: SOURCE_REF must be a 40-char hex SHA, got: ${SOURCE_REF}" >&2
+  exit 1
+fi
+
+git clone "${SOURCE_REPO}" proxy-src
 cd proxy-src
-git checkout ${SOURCE_REF}
+git checkout "${SOURCE_REF}"
 
 LOCAL_JOBS=$(( $(nproc) * 3 / 4 ))
 LOCAL_RAM=$(( $(free -m | awk '/^Mem:/{print $2}') * 85 / 100 ))


### PR DESCRIPTION
## Summary

The current `build.yaml` fires on `pull_request_target` for every PR, producing spurious FAILURE CheckRuns for private org members and external contributors even when Testing Farm builds run correctly through the `workflow_dispatch` path. A stale label snapshot attack was also possible in the previous design.

This PR redesigns the CI authorization layer by separating concerns:

- **New `ci-auth.yaml`**: handles `pull_request_target` events and decides whether to dispatch `build.yaml`. Public members are trusted immediately via `author_association`; private members and bot PRs that already carry `ok-to-test` are handled via a live API check; external contributors receive `needs-ok-to-test` and no build is dispatched.
- **`build.yaml`**: now triggered exclusively by `workflow_dispatch`. Eliminates `pull_request_target` trigger, `manage-labels` job, and the `Check authorization` step. Adds a concurrency group (`build-pr-{N}`, `cancel-in-progress: true`) so new commits automatically cancel stale builds. Input validation guards against malformed `head_sha` and `source_repo` values.
- **`ok-to-test.yaml`**: consolidated into a single sequential job. Dispatch runs first; if it fails, `needs-ok-to-test` remains visible as a clear signal that CI did not start.
- **`merge-upstream.yaml`**: third-party actions pinned to immutable commit SHAs; permissions moved from workflow level to job level.
- **`plans/common.sh`**: `SOURCE_REPO` and `SOURCE_REF` validated before use and quoted in `git clone`/`git checkout` calls.
- **`.github/scripts/upload-to-gcs.sh`**: `trap EXIT` ensures the GCS service account key file is removed even when the upload fails.

## Security properties

- External contributors cannot trigger CI without explicit maintainer approval (ok-to-test label, Triage+ required to add it).
- Stale label snapshot attack eliminated: `build.yaml` never reads labels; authorization uses `author_association` and live API calls only.
- On `synchronize` or `reopened`, `ok-to-test` is removed for untrusted authors, invalidating previous authorization for the new commit.
- Third-party actions pinned to SHA to prevent supply chain attacks.

## How CI works after this PR

**Public org member** opens a PR:
`ci-auth.yaml` dispatches `build.yaml` immediately.

**Private org member with `ok-to-test`** opens a PR:
`ci-auth.yaml` adds `needs-ok-to-test`, then queries the live label list. If `ok-to-test` is already present, it removes `needs-ok-to-test` and dispatches the build directly.

**External contributor** opens a PR:
`needs-ok-to-test` is added. A maintainer reviews the code and adds `ok-to-test`; `ok-to-test.yaml` dispatches the build and removes `needs-ok-to-test`.

**New commit on an external PR** (after ok-to-test was granted):
`ci-auth.yaml` removes `ok-to-test` and adds `needs-ok-to-test`. The previous build continues against the reviewed commit; the new commit has no CI status and cannot merge until re-authorized.

## Related

- Closes PR#302 (previous attempt using a stale-label check that was vulnerable to race conditions)

