### PR TITLE
Backport istio-PR-7108 - Fix IPv4/IPv6 address encoding for s390x

### DIFF
--- a/source/extensions/common/workload_discovery/api.cc
+++ b/source/extensions/common/workload_discovery/api.cc
@@ -93,14 +93,13 @@ public:
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
         uint32_t value = ipv4->address();
         std::array<uint8_t, 4> output;
-        absl::little_endian::Store32(&output, value);
+        memcpy(output.data(), &value, 4);
         return tls_->get(std::string(output.begin(), output.end()));
       } else if (const auto ipv6 = address->ip()->ipv6(); ipv6) {
-        const uint64_t high = absl::Uint128High64(ipv6->address());
-        const uint64_t low = absl::Uint128Low64(ipv6->address());
+        const auto* sa = reinterpret_cast<const sockaddr_in6*>(address->sockAddr());
         std::array<uint8_t, 16> output;
-        absl::little_endian::Store64(&output, low);
-        absl::little_endian::Store64(&output[8], high);
+        static_assert(sizeof(sa->sin6_addr.s6_addr) == 16);
+        memcpy(output.data(), sa->sin6_addr.s6_addr, 16);
         return tls_->get(std::string(output.begin(), output.end()));
       }
     }


### PR DESCRIPTION
What this PR does / why we need it:
On s390x the workload metadata IP address lookup fails silently because absl::little_endian::Store32/Store64 encodes IP address bytes in little-endian order, which does not match how the xDS server stores addresses in workload.addresses (network byte order / big-endian). This causes GetMetadata() to always return empty results on s390x, breaking workload identity resolution and telemetry metadata labels.

It fixes workload metadata lookup on s390x, which was causing waypoint proxy to emit incomplete telemetry on s390x platform.

Tried cherry pick this fix upstream https://github.com/istio/proxy/pull/7108 but  https://github.com/istio/proxy/pull/7138 but was not merged. So raising the fix here. 
